### PR TITLE
Results table

### DIFF
--- a/global.r
+++ b/global.r
@@ -59,6 +59,41 @@ connecter <- setRefClass(Class = "connecter",
                                geom_line(data2,mapping = aes(x = Temperature, y = Model), color = "red") + #best fit 
                                geom_point(data1, mapping = aes(x = Temperature, y = (dA.dT/(Pathlength*Ct))/upper+min(Absorbance)), color = "blue") + #first derivative
                                theme_classic()
+                           },
+                           #returns the data needed to create the vant hoff plot
+                           gatherVantData = function(){
+                             data = .self$object$Method.2.data
+                             return(data)
+                           },
+                           #returns the individual fit table data
+                            fitData = function(){
+                             #sample = .self$object$Method.1.indvfits$Sample
+                             #ct = .self$object$Method.1.indvfits$Ct
+                             #h = .self$object$Method.1.indvfits$H
+                             #s = .self$object$Method.1.indvfits$S
+                             #g = .self$object$Method.1.indvfits$G
+                             #tm = .self$object$Method.1.indvfits$Tm
+                             #indvCurves = data.frame(sample, ct,h,g,tm)
+                             indvCurves=.self$object$Method.1.indvfits 
+                             return(indvCurves)
+                            },
+                           summaryData1 = function(){
+                             summaryData=.self$object$Summary
+                             #indvidualfits = summaryData[1,]
+                             #Tmversuslnct = summaryData[2,]
+                             #summary = data.frame(indvidualfits, Tmversuslnct)
+                             return(summaryData[1,])
+                           },
+                           summaryData2 = function(){
+                             summaryData=.self$object$Summary
+                             #indvidualfits = summaryData[1,]
+                             #Tmversuslnct = summaryData[2,]
+                             #summary = data.frame(indvidualfits, Tmversuslnct)
+                             return(summaryData[2,])
+                           },
+                           error = function(){
+                             error = .self$object[3]
+                             return(error)
                            }
                          )
 )

--- a/server.r
+++ b/server.r
@@ -1,4 +1,3 @@
-library(MeltR) #Needs to be removed when Anothy pushes code
 server <- function(input,output, session){
   #Reactive list variable 
   values <- reactiveValues(masterFrame = NULL,numReadings = NULL)
@@ -240,12 +239,7 @@ server <- function(input,output, session){
 
   #code that plots a van't hoff plot
   output$vantplots <- renderPlot({
-    Model <- paste(molStateVal,".2State", sep = "")
-    data <- meltR.A(data_frame = df,
-                    blank = 1,
-                    NucAcid = helix,
-                    Mmodel = Model)
-    caluclations <- data$Method.2.data
+    caluclations <- myConnecter$gatherVantData()
     InverseTemp <- caluclations$invT
     LnConcentraion <- caluclations$lnCt
     plot(LnConcentraion,InverseTemp)
@@ -253,18 +247,23 @@ server <- function(input,output, session){
   }, res = 100)
   
 #Code that outputs the results table
-output$resulttable <- renderTable({
-  Model <- paste(molStateVal,".2State", sep = "")
-  data <- meltR.A(data_frame = df,
-                  blank = 1,
-                  NucAcid = helix,
-                  Mmodel = Model)
-  caluclations <- data$Method.2.data
-  InverseTemp <- caluclations$invT
-  LnConcentraion <- caluclations$lnCt
-  plot(LnConcentraion,InverseTemp)
   
-}, res = 100)
+output$resulttable <- renderTable({
+  data <-myConnecter$fitData()
+  return(data)
+})
+output$summarytable <- renderTable({
+  data <-myConnecter$summaryData1()
+  return(data)
+})
+output$summarytable2 <- renderTable({
+  data <-myConnecter$summaryData2()
+  return(data)
+})
+output$error <- renderTable({
+  data <-myConnecter$error()
+  return(data)
+})
 }
 
 

--- a/server.r
+++ b/server.r
@@ -251,6 +251,20 @@ server <- function(input,output, session){
     plot(LnConcentraion,InverseTemp)
     
   }, res = 100)
+  
+#Code that outputs the results table
+output$resulttable <- renderTable({
+  Model <- paste(molStateVal,".2State", sep = "")
+  data <- meltR.A(data_frame = df,
+                  blank = 1,
+                  NucAcid = helix,
+                  Mmodel = Model)
+  caluclations <- data$Method.2.data
+  InverseTemp <- caluclations$invT
+  LnConcentraion <- caluclations$lnCt
+  plot(LnConcentraion,InverseTemp)
+  
+}, res = 100)
 }
 
 

--- a/ui.R
+++ b/ui.R
@@ -4,7 +4,6 @@ library(glue)
 library(methods)
 library(MeltR)
 library(shiny)
-library(sicegar)
 
 # The UI consists of a navbar page, with a single drop down menu, "File" , which contains a single option "Add data".
 
@@ -82,7 +81,13 @@ ui <- navbarPage(title = "MeltShiny",id = "navbar",
                             tabPanel("Results Table", 
                                      fluidPage(
                                        mainPanel(
-                                         plotOutput("resulttable"),
+                                         "Individual fits",
+                                         tableOutput("resulttable"),
+                                         "Summary Tables",
+                                         tableOutput("summarytable"),
+                                         tableOutput("summarytable2"),
+                                         "Error",
+                                         tableOutput("error")
                                        )
                                      )
                             )

--- a/ui.R
+++ b/ui.R
@@ -78,6 +78,13 @@ ui <- navbarPage(title = "MeltShiny",id = "navbar",
                                            plotOutput("vantplots"),
                                          )
                                        )
+                                     ),
+                            tabPanel("Results Table", 
+                                     fluidPage(
+                                       mainPanel(
+                                         plotOutput("resulttable"),
+                                       )
                                      )
+                            )
                             )
 ) 


### PR DESCRIPTION
In this batch of code I added a new tab to show the results tables that MeltR outputs. These mimic tables that were also shown on MeltWin. This allows the user to see the same results tables that they would have been able to view in MeltWin. This tab also shows all the tables in a more coinvent manner than the automatic output that the terminal provides. This closes issue 19. I also updated the code so that the van't hoff plots only rely on the global variables and no longer MeltR directly. 
![image](https://user-images.githubusercontent.com/99764800/205200312-0d151bb7-228f-42c0-a3c7-b9ad8233b779.png)
