### PR TITLE
Slider and Baseline Bar Alignment 

### DIFF
--- a/server.r
+++ b/server.r
@@ -101,28 +101,32 @@ server <- function(input,output, session){
                           #main-panel code
                           conditionalPanel(
                             condition = glue("!input.{firstDerivative} && !input.{bestFit}"),
-                            plotOutput(plotName)
+                            column(12,align="right",plotOutput(plotName,width="99%"))
                           ),
                           conditionalPanel(
                             condition = glue("input.{firstDerivative} && !input.{bestFit}"),
-                            plotOutput(plotDerivative)
+                            column(12,align="right",plotOutput(plotDerivative))
                           ),
                           conditionalPanel(
                             condition = glue("input.{bestFit} && !input.{firstDerivative}"),
-                            plotOutput(plotBestFit)
+                            column(12,align="right",plotOutput(plotBestFit))
                           ),
                           conditionalPanel(
                             condition = glue("input.{firstDerivative} && input.{bestFit}"),
-                            plotOutput(plotBoth)
+                            column(12,align="right",plotOutput(plotBoth))
                           ),
-                          sliderInput(plotSlider,
-                                      glue("Plot{i}: Range of values"),
-                                      min = xmin,
-                                      max = xmax,
-                                      value = c(xmin,xmax),
-                                      round = TRUE,
-                                      step = .10,
-                                      width = "85%")
+                          column(12, 
+                                 align = "left",
+                                 offset = 1,
+                                 sliderInput(plotSlider,
+                                             glue("Plot{i}: Range of values"),
+                                             min = xmin,
+                                             max = xmax,
+                                             value = c(xmin,xmax),
+                                             round = TRUE,
+                                             step = .10,
+                                             width = "88%")
+                          )
                         )
                       )
                     )


### PR DESCRIPTION
**Objective**
During our demo, our client requested that we attempt to align the slider with the plot's baseline bars for a seamless experience. This post aims to complete this request. 

**Help Wanted** 
Viewing the application 75% to 100% fullscreen aligns the components almost perfectly, however it is only when you gradually decrease the screen size that the alignment gets progressively worse. The two issues I believe are at hand are: dynamic collection of `sliderInput` objects not being able to be modified, and media queries are not supported in R Shiny. 

**What I have tried** 
-Media queries within a separate CSS file. Was not successful in modifying the `sliderInput` id, even when hardcoded. 
-Hard coded styling within the `sliderInput`. This attempt works, and is what is in place currently, however it does not cater for all screen widths. 

**Demonstration of Visuals**
Full Screen View...
<img width="1552" alt="Screen Shot 2023-01-28 at 1 29 39 PM" src="https://user-images.githubusercontent.com/114530395/215287653-8385a489-1176-441e-9fb1-93d36a5d0cec.png">

Minimized Screen View...
<img width="911" alt="Screen Shot 2023-01-28 at 1 30 12 PM" src="https://user-images.githubusercontent.com/114530395/215287682-03db83ee-621d-4c06-9c80-74a48805481d.png">
