### PR TITLE
Implemented a windows package installer script

### DIFF
--- a/code/install.R
+++ b/code/install.R
@@ -1,9 +1,15 @@
 #!/usr/bin/env Rscript --vanilla
 requiredPackages <- c("dplyr",
+                      "DT",
                       "ggplot2",
                       "glue",
+                      "devtools",
+                      "openxlsx",
+                      "plotly",
+                      "tidyverse",
                       "remotes",
                       "methods",
+                      "ggrepel",
                       "MeltR",
                       "shiny",
                       "shinyjs")

--- a/windowsPackageInstaller.bat
+++ b/windowsPackageInstaller.bat
@@ -1,0 +1,3 @@
+@echo off
+"C:\Program Files\R\R-4.2.2\bin\Rscript.exe" "code/install.R"
+pause


### PR DESCRIPTION
This update includes a R package installer file for windows. The windowsPackageInstaller.bat file can be double clicked like any exe file and will install all the necessary packages for MeltShiny. When the user double clicks the file, a terminal appears on screen and indicates whether any packages need to be downloaded, in which case it will proceed to do that. Once installation is completed, the user will be shown a list of all the necessary packages. A checkmark next to them indicates they were downloaded successfully. In this case, the user can press any key to exit the terminal. If a package was unsucessful in being installed, the terminal will show an x next to that package name. The terminal will also display a command for that package(s) that the user can enter in the RStudio command line interface for installing the typical way.

Below, is a how the terminal will look if all packages have already been installed on the computer, and everything was successful. 
![image](https://user-images.githubusercontent.com/98234007/227701633-94a46328-552f-480d-aefa-3137ebdb836b.png)
