### PR TITLE
Automatic Fitting Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+code/Rplots.pdf

--- a/code/global.r
+++ b/code/global.r
@@ -75,7 +75,13 @@ connecter <- setRefClass(Class = "connecter",
                                geom_point(data1, mapping = aes(x = Temperature, y = (dA.dT/(Pathlength*Ct))/upper+min(Absorbance)), color = "blue") + #first derivative
                                theme_classic()
                              },
-                           
+
+                            # Automatically Fit MeltR.A Object Through BLTrimmer
+                            executeBLTrimmer = function(object,iterations) {
+                              BLTrimmer(object,
+                                n.combinations = iterations)
+                            },
+
                            # Return the x value associated with the maximum y-value for the first derivative
                            getFirstDerivativeMax = function(sampleNum) {
                              data = .self$fdData[.self$fdData == sampleNum,]

--- a/code/global.r
+++ b/code/global.r
@@ -15,7 +15,8 @@ connecter <- setRefClass(Class = "connecter",
                                     "blank",
                                     "Mmodel",
                                     "object",
-                                    "fdData"
+                                    "fdData",
+                                    "fittedObject"
                                     ),
                          methods = list(
                            # Create MeltR object & first derivative data
@@ -78,7 +79,7 @@ connecter <- setRefClass(Class = "connecter",
 
                             # Automatically Fit MeltR.A Object Through BLTrimmer
                             executeBLTrimmer = function(object,iterations) {
-                              BLTrimmer(object,
+                              .self$fittedObject <- BLTrimmer(object,
                                 n.combinations = iterations)
                             },
 
@@ -118,12 +119,30 @@ connecter <- setRefClass(Class = "connecter",
                            
                            # Return the results for the three methods
                            summaryData1 = function(){
+                            if ( typeof(.self$fittedObject) == "S4" ) {
                              summaryData=.self$object$Summary
-                             return(summaryData[1,])
+                            } else{
+                              summaryData=.self$fittedObject$Ensemble.energies
+                              
+                            }
+                            return(summaryData[1,])
                              },
                            summaryData2 = function(){
+                             if ( typeof(.self$fittedObject) == "S4" ) {
                              summaryData=.self$object$Summary
-                             return(summaryData[2,])
+                            } else{
+                              summaryData=.self$fittedObject$Ensemble.energies
+                            }
+                            return(summaryData[2,])
+                             },
+
+                            summaryData3 = function(){
+                             if ( typeof(.self$fittedObject) == "S4" ) {
+                             summaryData=.self$object$Summary
+                            } else{
+                              summaryData=.self$fittedObject$Ensemble.energies
+                            }
+                            return(summaryData[3,])
                              },
                            
                            # Return the percent error for the methods

--- a/code/global.r
+++ b/code/global.r
@@ -147,8 +147,12 @@ connecter <- setRefClass(Class = "connecter",
                            
                            # Return the percent error for the methods
                            error = function(){
-                             error = .self$object[3]
-                             return(error)
-                             }
+                            if ( typeof(.self$fittedObject) == "S4" ) {
+                              error = .self$object[3]
+                            } else {
+                              error = .self$fittedObject$Fractional.error.between.methods
+                            }
+                            return(error)
+                            }
                            )
                          )

--- a/code/server.r
+++ b/code/server.r
@@ -250,6 +250,7 @@ server <- function(input,output, session){
       results$methodOne <- myConnecter$summaryData1()
       results$methodTwo <- myConnecter$summaryData2()
       results$methodThree <- myConnecter$summaryData3()
+      results$error <- myConnecter$error()
     })
     
     
@@ -301,8 +302,8 @@ server <- function(input,output, session){
       return(results$methodThree)
     })
     output$error <- renderTable({
-      data <-myConnecter$error()
-      return(data)
+      results$error <-myConnecter$error()
+      return(results$error)
     })
     
     # Save the Van't Hoff Plot as a pdf.

--- a/code/server.r
+++ b/code/server.r
@@ -247,16 +247,26 @@ server <- function(input,output, session){
     observeEvent(input$automaticFit,
     handlerExpr = {
       req(input$inputFileID)
-      showModal(modalDialog("Please wait while we fit your data...", footer=NULL))
-      object = myConnecter$object
-      n = input$automaticIterations
-      myConnecter$executeBLTrimmer(object,n)
-      results$methodOne <- myConnecter$summaryData1()
-      results$methodTwo <- myConnecter$summaryData2()
-      results$methodThree <- myConnecter$summaryData3()
-      results$error <- myConnecter$error()
-      showModal(modalDialog("Your data has been fit successfully! View ", HTML("<b>Results</b>"), " tab for updated results."))
-      shinyjs::disable(selector = '.navbar-nav a[data-value="Analysis"')
+      value = input$automaticIterations
+      if(!can_convert_to_numeric(value)) {
+        showModal(modalDialog("Please enter a number."))
+      } else {
+        value = as.integer(value)
+        if (value<=10) {
+        showModal(modalDialog("Please enter a number larger than 10."))
+        } else {
+          showModal(modalDialog("Please wait while we fit your data...", footer=NULL))
+          object = myConnecter$object
+          n = input$automaticIterations
+          myConnecter$executeBLTrimmer(object,n)
+          results$methodOne <- myConnecter$summaryData1()
+          results$methodTwo <- myConnecter$summaryData2()
+          results$methodThree <- myConnecter$summaryData3()
+          results$error <- myConnecter$error()
+          showModal(modalDialog("Your data has been fit successfully! View ", HTML("<b>Results</b>"), " tab for updated results."))
+          shinyjs::disable(selector = '.navbar-nav a[data-value="Analysis"')
+        }
+      }
     })
     
     

--- a/code/server.r
+++ b/code/server.r
@@ -110,6 +110,9 @@ server <- function(input,output, session){
                              # Necessary for removal of outliers from said plot.
                              vals <<- reactiveValues(
                                keeprows = rep(TRUE, nrow(calculations)))
+
+                            # Reeactive variable that handles the data outputted for the Results Table
+                            results <<- reactiveValues(methodOne=NULL,methodTwo=NULL,methodThree=NULL)
                            }
                          }
   )
@@ -244,6 +247,9 @@ server <- function(input,output, session){
       object = myConnecter$object
       n = input$automaticIterations
       myConnecter$executeBLTrimmer(object,n)
+      results$methodOne <- myConnecter$summaryData1()
+      results$methodTwo <- myConnecter$summaryData2()
+      results$methodThree <- myConnecter$summaryData3()
     })
     
     
@@ -282,12 +288,17 @@ server <- function(input,output, session){
       return(data)
     })
     output$summarytable <- renderTable({
-      data <-myConnecter$summaryData1()
-      return(data)
+      
+      results$methodOne <- myConnecter$summaryData1()
+      return(results$methodOne)
     })
     output$summarytable2 <- renderTable({
-      data <-myConnecter$summaryData2()
-      return(data)
+      results$methodTwo <-myConnecter$summaryData2()
+      return(results$methodTwo)
+    })
+    output$summarytable3 <- renderTable({
+      results$methodThree <- myConnecter$summaryData3()
+      return(results$methodThree)
     })
     output$error <- renderTable({
       data <-myConnecter$error()

--- a/code/server.r
+++ b/code/server.r
@@ -92,11 +92,10 @@ server <- function(input,output, session){
                                tempFrame <- rbind(tempFrame, t)
                                p <- p + 1
                                counter <<- counter + 1
-                               #print(head(tempFrame))
                              }
                              values$numReadings <- counter - 1
                              values$masterFrame <- rbind(values$masterFrame, tempFrame)
-                             print(head(values$masterFrame))
+                             
                              # Send stored input values to the connecter abstraction class, create 
                              # a connecter object, and store the result of calling one of it's functions.
                              myConnecter <<- connecter(df = values$masterFrame,

--- a/code/server.r
+++ b/code/server.r
@@ -236,6 +236,15 @@ server <- function(input,output, session){
         }
       }
     })
+
+    # Automatically Fit Data
+    observeEvent(input$automaticFit,
+    handlerExpr = {
+      req(input$inputFileID)
+      object = myConnecter$object
+      n = input$automaticIterations
+      myConnecter$executeBLTrimmer(object,n)
+    })
     
     
     # Create Van't Hoff plot for the "Van't Hoff Plot" Tab under the "Results" navbar menu.

--- a/code/server.r
+++ b/code/server.r
@@ -247,6 +247,7 @@ server <- function(input,output, session){
     observeEvent(input$automaticFit,
     handlerExpr = {
       req(input$inputFileID)
+      showModal(modalDialog("Please wait while we fit your data...", footer=NULL))
       object = myConnecter$object
       n = input$automaticIterations
       myConnecter$executeBLTrimmer(object,n)
@@ -254,6 +255,7 @@ server <- function(input,output, session){
       results$methodTwo <- myConnecter$summaryData2()
       results$methodThree <- myConnecter$summaryData3()
       results$error <- myConnecter$error()
+      showModal(modalDialog("Your data has been fit successfully! View ", HTML("<b>Results</b>"), " tab for updated results."))
     })
     
     

--- a/code/server.r
+++ b/code/server.r
@@ -256,6 +256,7 @@ server <- function(input,output, session){
       results$methodThree <- myConnecter$summaryData3()
       results$error <- myConnecter$error()
       showModal(modalDialog("Your data has been fit successfully! View ", HTML("<b>Results</b>"), " tab for updated results."))
+      shinyjs::disable(selector = '.navbar-nav a[data-value="Analysis"')
     })
     
     

--- a/code/server.r
+++ b/code/server.r
@@ -92,10 +92,11 @@ server <- function(input,output, session){
                                tempFrame <- rbind(tempFrame, t)
                                p <- p + 1
                                counter <<- counter + 1
+                               #print(head(tempFrame))
                              }
                              values$numReadings <- counter - 1
                              values$masterFrame <- rbind(values$masterFrame, tempFrame)
-                             
+                             print(head(values$masterFrame))
                              # Send stored input values to the connecter abstraction class, create 
                              # a connecter object, and store the result of calling one of it's functions.
                              myConnecter <<- connecter(df = values$masterFrame,
@@ -118,7 +119,10 @@ server <- function(input,output, session){
   )
 
     # Output the post-processed data frame, which contains all the appended datasets.
-    output$table <- renderTable({return(values$masterFrame)})
+    output$table <- renderTable({
+      req(input$inputFileID)
+      values$masterFrame$Absorbance <- sprintf("%.11s", values$masterFrame$Absorbance)
+      return(values$masterFrame)})
     
     # Hide "Analysis" and "Results tabs until a file is successfully uploaded
     observeEvent(eventExpr = is.null(values$numReadings),

--- a/code/style.R
+++ b/code/style.R
@@ -1,0 +1,7 @@
+css <- "
+.nav li a.disabled {
+background-color: #aaa !important;
+color: #333 !important;
+cursor: not-allowed !important;
+border-color: #aaa !important;
+}"  

--- a/code/ui.R
+++ b/code/ui.R
@@ -17,12 +17,14 @@ ui <- navbarPage(title = "MeltShiny",
                                                          ),
                                            textInput(label = "Enter the pathlength for each sample. (Note, these values should be separated by commas
                                                      and have no spaces in between them.) If there are no blanks, enter the word none.",
-                                                     placeholder = "E.g: 2,5,3,2",
+                                                     #placeholder = "E.g: 2,5,3,2",
+                                                     value = "1,1,1,1,1,1,1,1,1,1",
                                                      inputId = "pathlengthID"
                                                      ),
                                            textInput(label = "Enter the sequence information in the following order: a nucleic acid, a sequence, and, if applicable, its complement).
                                                               (Note, these values should be seperated by commas and have no spaces in between them.)",
-                                                     placeholder = "E.g: RNA,CGAAAGGU,ACCUUUCG",
+                                                     #placeholder = "E.g: RNA,CGAAAGGU,ACCUUUCG",
+                                                     value = "RNA, CGAAAGGU, ACCUUUCG",
                                                      inputId = "helixID"
                                                      ),
                                            selectInput(label = "Select the molecular state.", 
@@ -52,9 +54,22 @@ ui <- navbarPage(title = "MeltShiny",
                                      ),
                             tabPanel(title = "Fit",
                                      tabsetPanel(type = "tabs",
-                                                 tabPanel("Manual"),
-                                                 tabPanel("Automatic")
-                                                 )
+                                      tabPanel("Manual"),
+                                      tabPanel("Automatic",
+                                        fluidPage(
+                                          mainPanel(
+                                            h2("Automatic Fitting"),
+                                            textInput(label = "Enter the iterations for BLTrimmer to test.",
+                                            value = 10000,
+                                            inputId = "automaticIterations"
+                                            ),
+                                            actionButton(inputId = "automaticFit",
+                                              label = "Fit"
+                                            )
+                                          )
+                                        )
+                                      )
+                                    )
                                      )
                             ),
                  navbarMenu(title = "Results",

--- a/code/ui.R
+++ b/code/ui.R
@@ -1,3 +1,11 @@
+css <- "
+.nav li a.disabled {
+background-color: #aaa !important;
+color: #333 !important;
+cursor: not-allowed !important;
+border-color: #aaa !important;
+}"
+
 ui <- navbarPage(title = "MeltShiny",
                  id = "navbarPageID",
                  navbarMenu(title = "File",
@@ -5,7 +13,8 @@ ui <- navbarPage(title = "MeltShiny",
                                      fluidPage(
                                        sidebarLayout(
                                          sidebarPanel(
-                                           useShinyjs(),
+                                           shinyjs::useShinyjs(),
+                                           shinyjs::inlineCSS(css),
                                            textInput(label = "Enter the blank sample.",
                                                      placeholder = "E.g: 1",
                                                      value = 1,

--- a/code/ui.R
+++ b/code/ui.R
@@ -64,7 +64,7 @@ ui <- navbarPage(title = "MeltShiny",
                                       tabPanel("Manual"),
                                       tabPanel("Automatic",
                                         fluidPage(
-                                            textInput(label = "Number to fit data to",
+                                            textInput(label = "Please enter a number larger than 10",
                                             value = 1000,
                                             inputId = "automaticIterations"
                                             ),

--- a/code/ui.R
+++ b/code/ui.R
@@ -17,14 +17,12 @@ ui <- navbarPage(title = "MeltShiny",
                                                          ),
                                            textInput(label = "Enter the pathlength for each sample. (Note, these values should be separated by commas
                                                      and have no spaces in between them.) If there are no blanks, enter the word none.",
-                                                     #placeholder = "E.g: 2,5,3,2",
-                                                     value = "1,1,1,1,1,1,1,1,1,1",
+                                                     placeholder = "E.g: 2,5,3,2",
                                                      inputId = "pathlengthID"
                                                      ),
                                            textInput(label = "Enter the sequence information in the following order: a nucleic acid, a sequence, and, if applicable, its complement).
                                                               (Note, these values should be seperated by commas and have no spaces in between them.)",
-                                                     #placeholder = "E.g: RNA,CGAAAGGU,ACCUUUCG",
-                                                     value = "RNA, CGAAAGGU, ACCUUUCG",
+                                                     placeholder = "E.g: RNA,CGAAAGGU,ACCUUUCG",
                                                      inputId = "helixID"
                                                      ),
                                            selectInput(label = "Select the molecular state.", 

--- a/code/ui.R
+++ b/code/ui.R
@@ -1,10 +1,4 @@
-css <- "
-.nav li a.disabled {
-background-color: #aaa !important;
-color: #333 !important;
-cursor: not-allowed !important;
-border-color: #aaa !important;
-}"
+source("style.R")
 
 ui <- navbarPage(title = "MeltShiny",
                  id = "navbarPageID",

--- a/code/ui.R
+++ b/code/ui.R
@@ -55,16 +55,13 @@ ui <- navbarPage(title = "MeltShiny",
                                       tabPanel("Manual"),
                                       tabPanel("Automatic",
                                         fluidPage(
-                                          mainPanel(
-                                            h2("Automatic Fitting"),
-                                            textInput(label = "Enter the iterations for BLTrimmer to test.",
+                                            textInput(label = "Number to fit data to",
                                             value = 1000,
                                             inputId = "automaticIterations"
                                             ),
                                             actionButton(inputId = "automaticFit",
-                                              label = "Fit"
+                                              label = "Fit Data"
                                             )
-                                          )
                                         )
                                       )
                                     )

--- a/code/ui.R
+++ b/code/ui.R
@@ -117,6 +117,7 @@ ui <- navbarPage(title = "MeltShiny",
                                            h5("Summary of the Three Methods:"),
                                            tableOutput(outputId = "summarytable"),
                                            tableOutput(outputId = "summarytable2"),
+                                           tableOutput(outputId = "summarytable3"),
                                            h5("Percent Error Between Methods:"),
                                            tableOutput(outputId = "error")
                                            )

--- a/code/ui.R
+++ b/code/ui.R
@@ -60,7 +60,7 @@ ui <- navbarPage(title = "MeltShiny",
                                           mainPanel(
                                             h2("Automatic Fitting"),
                                             textInput(label = "Enter the iterations for BLTrimmer to test.",
-                                            value = 10000,
+                                            value = 1000,
                                             inputId = "automaticIterations"
                                             ),
                                             actionButton(inputId = "automaticFit",


### PR DESCRIPTION
## Overview

This pull request brings fitting to our application, more specifically automatic fitting. This is done using MeltR's **BLTrimmer** function to test different baselines from an inputted number. If the user opts to utilize automatic fitting, selective results update upon automatically fitting. More specifically the "summary of the three methods" and the "% error between methods".
Closes #74 

## Changes Made 

- Added `Rplots.pdf` to `.gitignore`. This is an unnecessary auto-generated file. 
- Implemented UI for "Automatic" tabsetPanel.
- Added Method 3 to the "Summary of the Three Methods" within the Results Table
- Selective results update upon automatically fitting. 
- Updated Absorbance readings within the table to accurately display the correct values. 

## Demonstrations

**Figure 1** highlights the fixed values for the data table that is presented upon file upload. Previously, values would consistently show 0.00 or -0.00.
<img width="1234" alt="Screenshot 2023-04-16 at 1 00 15 PM" src="https://user-images.githubusercontent.com/114530395/232332391-3851db32-43e8-4ac1-bd14-7b2ebb1ecf19.png">


**Figure 2** shows the ui for the "Automatic" fit tab.
<img width="1234" alt="Screenshot 2023-04-16 at 1 00 57 PM" src="https://user-images.githubusercontent.com/114530395/232332422-32b1c797-e7c2-4e2e-8a44-4e4f8f383cc4.png">


**Figure 3** highlights the pop-up that is presented while the data is being fitted. 
<img width="1234" alt="Screenshot 2023-04-16 at 1 01 15 PM" src="https://user-images.githubusercontent.com/114530395/232332434-09a5718b-ca97-4d5f-9e05-9e3a8e3b15a3.png">

**Figure 4** highlights the pop-up that is presented when the data is done being fitted. 
<img width="1234" alt="Screenshot 2023-04-16 at 1 01 34 PM" src="https://user-images.githubusercontent.com/114530395/232332457-55ccec08-ea45-4b77-9cd8-52da98a3a7b9.png">
