### PR TITLE
command/batch scripts for updated zip contents

### DIFF
--- a/MacOS_Scripts/MeltShinyUpdate.command
+++ b/MacOS_Scripts/MeltShinyUpdate.command
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+ZIP_URL="https://github.com/oss-slu/MeltWin2.0/archive/refs/heads/main.zip"
+
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+PROGRAM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Create a temporary directory
+mkdir -p "/tmp/UpdateTemp"
+# Download the latest ZIP archive
+curl -L -o "/tmp/UpdateTemp/latest.zip" "$ZIP_URL"
+# Unzip the archive to the temporary location
+unzip -o "/tmp/UpdateTemp/latest.zip" -d "/tmp/UpdateTemp"
+
+# Delete all existing files and directories inside MeltWin2.0, excluding MacOS_Scripts and Windows_Scripts
+find "$PROGRAM_DIR" -mindepth 1 -maxdepth 1 ! -name 'MacOS_Scripts' ! -name 'Windows_Scripts' -exec rm -rf {} \;
+# Copy the contents of the unzipped folder to the program directory
+cp -R "/tmp/UpdateTemp/MeltWin2.0-main/"* "$PROGRAM_DIR"
+
+# Clean up the temporary directory
+rm -r "/tmp/UpdateTemp"
+
+echo "Update complete! Your program is now up to date."
+exit 0
+

--- a/Windows_Scripts/MeltShinyUpdate.bat
+++ b/Windows_Scripts/MeltShinyUpdate.bat
@@ -1,0 +1,36 @@
+@echo off
+setlocal
+
+:: Define the URL of the latest ZIP archive
+set ZIP_URL=https://github.com/oss-slu/MeltWin2.0/archive/refs/heads/main.zip
+
+:: Determine the directory where the script is located (Windows_Scripts)
+set SCRIPT_DIR=%~dp0
+
+:: Define the directory where the program is installed
+cd %SCRIPT_DIR%\..
+set PROGRAM_DIR=%cd%
+cd %SCRIPT_DIR%
+
+:: Create a temporary directory
+set TEMP_DIR=%TEMP%\UpdateTemp
+mkdir "%TEMP_DIR%"
+:: Download the latest ZIP archive
+powershell -Command "& { Invoke-WebRequest -Uri '%ZIP_URL%' -OutFile '%TEMP_DIR%\latest.zip' }"
+:: Unzip the archive to a temporary location
+powershell -Command "& { Expand-Archive -Path '%TEMP_DIR%\latest.zip' -DestinationPath '%TEMP_DIR%' -Force }"
+
+:: Delete all existing files and directories inside MeltWin2.0, excluding Windows_Scripts and MacOS_Scripts
+for /D %%A in ("%PROGRAM_DIR%\*") do (
+    if /I not "%%~nxA"=="Windows_Scripts" if /I not "%%~nxA"=="MacOS_Scripts" (
+        rd /s /q "%%~fA"
+    )
+)
+:: Copy the contents of the unzipped folder to the program directory
+xcopy /E /I /Y "%TEMP_DIR%\MeltWin2.0-main\*" "%PROGRAM_DIR%\"
+
+:: Clean up the temporary directory
+rd /s /q "%TEMP_DIR%"
+
+echo Update complete! Your program is now up to date.
+pause


### PR DESCRIPTION
Addresses Issue #87 

Command script and Batch script files were created within respective script subdirectories to download the latest codebase as a zip file, extract its code subdirectory contents, replace local MeltWin2.0/code with the new updated contents, and clean up temporary storage space. Note the Windows script hasn't been tested since I own only Mac machines.

FOR TESTING/REVIEW PURPOSES:
Since by the nature of the issue, administrator permissions are required for these update scripts. If permissions are granted to run both dependencies and application scripts, then that should be sufficient for the update script. To test, pull this PR into local and create a copy directory before attempting to run update script. This is because the directory is replaced via contents of the zip and will no longer be the same git repository linked to remote. 

If permission is denied, then scripts need to be run as admin (for Mac, terminal chmod a+x /your-script-path and for Windows, this should just require run as admin). This wasn't seen as an issue in development since this is required to run the application in the first place. 