### PR TITLE
Issue95fix

### DIFF
--- a/MacOS_Scripts/MeltShinyUpdate.command
+++ b/MacOS_Scripts/MeltShinyUpdate.command
@@ -1,9 +1,19 @@
 #!/bin/bash
 
-ZIP_URL="https://github.com/oss-slu/MeltWin2.0/archive/refs/heads/main.zip"
-
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 PROGRAM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Get the name of the program directory
+PROGRAM_NAME="$(basename "$PROGRAM_DIR")"
+
+# Check if the program directory is named 'MeltWin2.0-main'
+if [ "$PROGRAM_NAME" != "MeltWin2.0-main" ]; then
+    echo "Error: The parent directory is not 'MeltWin2.0-main'! Exiting..."
+    exit 1
+fi
+
+ZIP_URL="https://github.com/oss-slu/MeltWin2.0/archive/refs/heads/main.zip"
+CODE_DIR="$PROGRAM_DIR/code" # specify the Code subdirectory
 
 # Create a temporary directory
 mkdir -p "/tmp/UpdateTemp"
@@ -12,14 +22,13 @@ curl -L -o "/tmp/UpdateTemp/latest.zip" "$ZIP_URL"
 # Unzip the archive to the temporary location
 unzip -o "/tmp/UpdateTemp/latest.zip" -d "/tmp/UpdateTemp"
 
-# Delete all existing files and directories inside MeltWin2.0, excluding MacOS_Scripts and Windows_Scripts
-find "$PROGRAM_DIR" -mindepth 1 -maxdepth 1 ! -name 'MacOS_Scripts' ! -name 'Windows_Scripts' -exec rm -rf {} \;
-# Copy the contents of the unzipped folder to the program directory
-cp -R "/tmp/UpdateTemp/MeltWin2.0-main/"* "$PROGRAM_DIR"
+# Delete only the 'code' subdirectory inside PROGRAM_DIR
+rm -rf "$CODE_DIR"
+# Copy the 'code' subdirectory from the unzipped folder to PROGRAM_DIR
+cp -R "/tmp/UpdateTemp/MeltWin2.0-main/code" "$PROGRAM_DIR"
 
 # Clean up the temporary directory
 rm -r "/tmp/UpdateTemp"
 
-echo "Update complete! Your program is now up to date."
+echo "Update complete! Your program's 'code' subdirectory is now up to date."
 exit 0
-

--- a/README.md
+++ b/README.md
@@ -1,33 +1,45 @@
 # MeltShiny Documentation
 
 ## Problem: MeltWin
+
 Researchers are currently using a legacy program called MeltWin to fit DNA absorbance melting curves to obtain folding information in the form of thermodynamic parameters. MeltWin was designed over 20 years ago, and as such, is not optimized for modern systems, and is only capable of running on Windows. Furthermore, a lack of source code makes modification impossible. There is a need for a program that both includes the functions of MeltWin, is capable of taking advantage of major modern operating systems such as Windows and MacOS, introduces automation, and provides an intuitive user interface, all goals of the MeltShiny open-source program.
 
 ## Bridge: MeltR
-MeltShiny's functionality relies on an existing open-source package written in the R programming language called MeltR. It was developed by Jacob Sieg of Penn State University. MeltR possesses many of the same calculation and fitting abilities as its predecessor, MeltWin. Specifically, both MeltR and MeltWin provide easy and consistent fitting of nucleic acid folding data to obtain thermodynamic parameters. MeltR’s features are more robust and require less user input compared to MeltWin. However, unlike MeltWin which has a graphical user interface, MeltR requires that users interact with it via the R console. Typing commands into a command line interface can be tedious and require technical knowledge. 
+
+MeltShiny's functionality relies on an existing open-source package written in the R programming language called MeltR. It was developed by Jacob Sieg of Penn State University. MeltR possesses many of the same calculation and fitting abilities as its predecessor, MeltWin. Specifically, both MeltR and MeltWin provide easy and consistent fitting of nucleic acid folding data to obtain thermodynamic parameters. MeltR’s features are more robust and require less user input compared to MeltWin. However, unlike MeltWin which has a graphical user interface, MeltR requires that users interact with it via the R console. Typing commands into a command line interface can be tedious and require technical knowledge.
 
 ## Solution: MeltShiny
+
 MeltShiny eliminates the need for the console, as it provides an intuitive graphical user interface that can be used by individuals of all skill levels. Relying on the robust and reliable calculations of MeltR, MeltShiny's benefits also extend to its functionality. Users are provided with automated processing of input files, as well as the automated removal of outliers from both the Van't Hoff plot and the results table. The end result is a program that provides researchers with the best possible workflow, reducing the time they have to spend interacting with a computer and increasing the time they have for research and analysis.
 
 ## Research
+
 Researchers hope to understand the function of different DNA and RNA molecules. Researchers shine light through these molecules and record the absorption data. Due to intricate baseparing and folding patterns, the absorption data for specific RNA and DNA molecules will be unique. This data can mathematically be translated through the fitting of absorbance melting curves into thermodynamic parameters to obtain folding information.
 
 ## MeltShiny Installation Instructions
+
 ### Installing R
+
 To run MeltShiny you need to download R. Go to the RStudio website, https://posit.co/download/rstudio-desktop/. There, you will see two download options. Only R is required. Download R according to your system.
 
 ### Downloading the MeltShiny Repository
-Go to the following website https://github.com/oss-slu/MeltWin2.0. This link will take you to the MeltShiny GitHub repository where you can download the MeltShiny application. To download from the repository, click the green button that says "clone" and click download ZIP. Once downloaded, extract the folder. Move the extracted folder to whereever you so choose. Upon opening this folder, you will find three folders: code, Windows_Scripts, and MacOS_Scripts. The code folder should not be touched. Depending on your system, you will be using either the Windows or MacOS script folders. 
+
+Go to the following website https://github.com/oss-slu/MeltWin2.0. This link will take you to the MeltShiny GitHub repository where you can download the MeltShiny application. To download from the repository, click the green button that says "clone" and click download ZIP. Once downloaded, extract the folder. Move the extracted folder to whereever you so choose. Upon opening this folder, you will find three folders: code, Windows_Scripts, and MacOS_Scripts. The code folder should not be touched. Depending on your system, you will be using either the Windows or MacOS script folders.
 
 ### Updating the MeltShiny Program
-To obtain the latest version of the MeltShiny program, you should delete the MeltShiny folder in your selected location and following the sames steps as before to download the new version from the MeltShiny page. 
+
+To obtain the latest version of the MeltShiny program, update scripts have been included, with names MeltShinyUpdate.command and MeltShinyUpdate.bat for MacOS and Windows, respectively. These files are found within the MacOS_Scripts and Windows_Scripts folders within the MeltShiny application bundle. Per the nature of deleting and replacing directories, ensure that you have not changed the file structure of the MeltShiny package; the code and Mac/Windows script subdirectories should remain within the MeltWin2.0-man directory the package is wrapped in. Although checks have been put in place for any deviations to this, we recommend leaving the file structure as is to ensure there are no unforeseen consequences.
+
+Double clicking MeltShinyUpdate.command or MeltShinyUpdate.bat for Mac and Windows, respectively, will open up a terminal. This terminal will display the progress of downloading the main zip file from the GitHub page as well as progress of downloading/extracting its contents. In the end, the contents of the code subdirectory will be replaced with updated versions and the terminal will state your program is up to date. Otherwise, the respective error message will appear as to what went wrong.
 
 ### Installing Dendencies
+
 MeltShiny has some dependencies which will need to be installed for the program to run. R Package installer files have been included, with the names MeltShinyDependenciesInstaller.command and MeltShinyDependenciesInstaller.bat for MacOS and Windows, respectively. These files are found within the MacOS_Scripts and Windows_Scripts folders found within the MeltShiny application bundle.Note, that in order for the Windows version to work, you must add the R bin folder to your PATH variable. For MacOS, the script can be used without any additional work.
 
-Double clicking MeltShinyDependenciesInstaller.command or MeltShinyDependenciesInstaller.bat for Mac and Windows, respectively, open up a terminal. The terminal will display the progress of each package as they are installed. In the end, all the packages will be shown in a list format with either a check or an x next to them. All packages with a check next to them were successfully installed. You can then close the terminal.
+Double clicking MeltShinyDependenciesInstaller.command or MeltShinyDependenciesInstaller.bat for Mac and Windows, respectively, will open up a terminal. The terminal will display the progress of each package as they are installed. In the end, all the packages will be shown in a list format with either a check or an x next to them. All packages with a check next to them were successfully installed. You can then close the terminal.
 
 ### Adding R to Path (Windows Only)
+
 The following steps will guide you through this process, which only needs to be done once.
 
 1. Using Windows search, type environment. A search option will appear titled "Edit the system environment variables". Click this.
@@ -38,9 +50,10 @@ The following steps will guide you through this process, which only needs to be 
 
 4. Click on a blank row and ensure none of the rows are highlighted.
 
-5. In the next window that pops up, click the “Browse” button. Using the file explorer that pops up, locate your R bin folder. If you chose to install R in the default location during R installation process, the path will follow the format: "C:\Program Files\R\R-version\bin", where the R-version will depend on the version of R you have installed. For example, a user who has an R version of 4.2.2 will have a path of "C:\Program Files\R\R-4.2.2\bin". 
+5. In the next window that pops up, click the “Browse” button. Using the file explorer that pops up, locate your R bin folder. If you chose to install R in the default location during R installation process, the path will follow the format: "C:\Program Files\R\R-version\bin", where the R-version will depend on the version of R you have installed. For example, a user who has an R version of 4.2.2 will have a path of "C:\Program Files\R\R-4.2.2\bin".
 
 6. Once you have added the R bin folder to your PATH variable, press ok and ok again to close the environment manager.
 
 ## Running MeltShiny
+
 Double clicking the MeltShiny.command and MeltShiny.bat for Mac and Windows, respectively, will open a terminal. The terminal will show some numbers before starting the MeltShiny application in your default web browser. This program uses a local host, so the contents you provide in the program are localized to your computer. Should the application not open automatically, copy the numbers at the bottom of the terminal into a browser tab. Note, the terminal must remain open for the MeltShiny application to run. Once you are done with your MeltShiny session, close out of the application tab and close the terminal.

--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ To run MeltShiny you need to download R. Go to the RStudio website, https://posi
 
 Go to the following website https://github.com/oss-slu/MeltWin2.0. This link will take you to the MeltShiny GitHub repository where you can download the MeltShiny application. To download from the repository, click the green button that says "clone" and click download ZIP. Once downloaded, extract the folder. Move the extracted folder to whereever you so choose. Upon opening this folder, you will find three folders: code, Windows_Scripts, and MacOS_Scripts. The code folder should not be touched. Depending on your system, you will be using either the Windows or MacOS script folders.
 
-### Updating the MeltShiny Program
-
-To obtain the latest version of the MeltShiny program, update scripts have been included, with names MeltShinyUpdate.command and MeltShinyUpdate.bat for MacOS and Windows, respectively. These files are found within the MacOS_Scripts and Windows_Scripts folders within the MeltShiny application bundle. Per the nature of deleting and replacing directories, ensure that you have not changed the file structure of the MeltShiny package; the code and Mac/Windows script subdirectories should remain within the MeltWin2.0-man directory the package is wrapped in. Although checks have been put in place for any deviations to this, we recommend leaving the file structure as is to ensure there are no unforeseen consequences.
-
-Double clicking MeltShinyUpdate.command or MeltShinyUpdate.bat for Mac and Windows, respectively, will open up a terminal. This terminal will display the progress of downloading the main zip file from the GitHub page as well as progress of downloading/extracting its contents. In the end, the contents of the code subdirectory will be replaced with updated versions and the terminal will state your program is up to date. Otherwise, the respective error message will appear as to what went wrong.
-
 ### Installing Dendencies
 
 MeltShiny has some dependencies which will need to be installed for the program to run. R Package installer files have been included, with the names MeltShinyDependenciesInstaller.command and MeltShinyDependenciesInstaller.bat for MacOS and Windows, respectively. These files are found within the MacOS_Scripts and Windows_Scripts folders found within the MeltShiny application bundle.Note, that in order for the Windows version to work, you must add the R bin folder to your PATH variable. For MacOS, the script can be used without any additional work.
@@ -57,3 +51,9 @@ The following steps will guide you through this process, which only needs to be 
 ## Running MeltShiny
 
 Double clicking the MeltShiny.command and MeltShiny.bat for Mac and Windows, respectively, will open a terminal. The terminal will show some numbers before starting the MeltShiny application in your default web browser. This program uses a local host, so the contents you provide in the program are localized to your computer. Should the application not open automatically, copy the numbers at the bottom of the terminal into a browser tab. Note, the terminal must remain open for the MeltShiny application to run. Once you are done with your MeltShiny session, close out of the application tab and close the terminal.
+
+### Updating the MeltShiny Program
+
+To obtain the latest version of the MeltShiny program, update scripts have been included, with names MeltShinyUpdate.command and MeltShinyUpdate.bat for MacOS and Windows, respectively. These files are found within the MacOS_Scripts and Windows_Scripts folders within the MeltShiny application bundle. Per the nature of deleting and replacing directories, ensure that you have not changed the file structure of the MeltShiny package; the code and Mac/Windows script subdirectories should remain within the MeltWin2.0-man directory the package is wrapped in. Although checks have been put in place for any deviations to this, we recommend leaving the file structure as is to ensure there are no unforeseen consequences.
+
+Double clicking MeltShinyUpdate.command or MeltShinyUpdate.bat for Mac and Windows, respectively, will open up a terminal. This terminal will display the progress of downloading the main zip file from the GitHub page as well as progress of downloading/extracting its contents. In the end, the contents of the code subdirectory will be replaced with updated versions and the terminal will state your program is up to date. Otherwise, the respective error message will appear as to what went wrong.

--- a/Windows_Scripts/MeltShinyUpdate.bat
+++ b/Windows_Scripts/MeltShinyUpdate.bat
@@ -12,6 +12,19 @@ cd %SCRIPT_DIR%\..
 set PROGRAM_DIR=%cd%
 cd %SCRIPT_DIR%
 
+:: Get the name of the program directory
+for %%a in (%PROGRAM_DIR%) do set PROGRAM_NAME=%%~nxa
+
+:: Check if the program directory is named 'MeltWin2.0-main'
+if /I not "%PROGRAM_NAME%"=="MeltWin2.0-main" (
+    echo Error: The parent directory is not 'MeltWin2.0-main'! Exiting...
+    pause
+    exit /b 1
+)
+
+:: Define the 'code' subdirectory inside PROGRAM_DIR
+set CODE_DIR=%PROGRAM_DIR%\code
+
 :: Create a temporary directory
 set TEMP_DIR=%TEMP%\UpdateTemp
 mkdir "%TEMP_DIR%"
@@ -20,17 +33,13 @@ powershell -Command "& { Invoke-WebRequest -Uri '%ZIP_URL%' -OutFile '%TEMP_DIR%
 :: Unzip the archive to a temporary location
 powershell -Command "& { Expand-Archive -Path '%TEMP_DIR%\latest.zip' -DestinationPath '%TEMP_DIR%' -Force }"
 
-:: Delete all existing files and directories inside MeltWin2.0, excluding Windows_Scripts and MacOS_Scripts
-for /D %%A in ("%PROGRAM_DIR%\*") do (
-    if /I not "%%~nxA"=="Windows_Scripts" if /I not "%%~nxA"=="MacOS_Scripts" (
-        rd /s /q "%%~fA"
-    )
-)
-:: Copy the contents of the unzipped folder to the program directory
-xcopy /E /I /Y "%TEMP_DIR%\MeltWin2.0-main\*" "%PROGRAM_DIR%\"
+:: Delete the existing 'code' subdirectory inside PROGRAM_DIR
+rd /s /q "%CODE_DIR%"
+:: Copy the 'code' subdirectory from the unzipped folder to PROGRAM_DIR
+xcopy /E /I /Y "%TEMP_DIR%\MeltWin2.0-main\code\*" "%CODE_DIR%\"
 
 :: Clean up the temporary directory
 rd /s /q "%TEMP_DIR%"
 
-echo Update complete! Your program is now up to date.
+echo Update complete! Your program's 'code' subdirectory is now up to date.
 pause


### PR DESCRIPTION
Addresses an issue our client reached out to us for regarding recent changes in issue #95

The original implementations regarding the update scripts was accurate but did not address an edge case. This being if users altered the file structure of the MeltWin2.0 application when unzipping its contents. The original implementation deleted all neighboring subdirectories to the update script directory and replaced with updated contents of the application. This could potentially cause loss of important data on user drives, given this specific circumstance.

This change implements a check on the name of the parent directory, to ensure that the program file structure is as is defined by the repository. In addition, only the contents within the code subdirectory will be updated. For updates regarding changes to script logic (dependencies, program start, and update), users will need to download directly from the repository. This might change in a later issue, but for now this ensures no potential unwanted outcomes.

For testing purposes, download this branch via zip and add/delete files within the code subdirectory before running the update script. The contents of the code subdirectory should then once again be accurate. In addition, make a copy of the application and rename it from MeltWin2.0-main to something else, and ensure that the update scripts fail to execute.