### PR TITLE
Issue95

### DIFF
--- a/code/global.r
+++ b/code/global.r
@@ -117,6 +117,16 @@ connecter <- setRefClass(
               x1 = data$Temperature[which.max(data$dA.dT)], line = list(width = 1, dash = "dot"), editable = FALSE
             )
           ),
+          annotations = list(
+            list(
+              x = data$Temperature[which.max(data$dA.dT)],
+              y = 1.02, # slightly above the dotted line
+              yref = "paper",
+              text = sprintf("Max Derivative @ %.3f", data$Temperature[which.max(data$dA.dT)]),
+              showarrow = FALSE,
+              xanchor = "left"
+            )
+          ),
           xaxis = list(dtick = 5)
         ) %>%
         rangeslider(xRange[[sampleNum]][1], xRange[[sampleNum]][2], thickness = .1) %>%

--- a/code/global.r
+++ b/code/global.r
@@ -101,8 +101,8 @@ connecter <- setRefClass(
       coeff <- 4000 # Static number to shrink data to scale
       upper <- max(data$dA.dT) / max(data$Ct) + coeff
 
-      # Filter data within the temperature range 25 to 65 (transition range)
-      filteredData <- data[data$Temperature >= 25 & data$Temperature <= 65, ]
+      # Filter data within the temperature range 20 to 70 (transition range)
+      filteredData <- data[data$Temperature >= 20 & data$Temperature <= 70, ]
       
       # Find the temperature of the max derivative within the filtered data
       maxDerivativeTemp <- filteredData$Temperature[which.max(filteredData$dA.dT)]


### PR DESCRIPTION
This PR addresses issue #95. This issue required the temperature at which the peak of the first derivative on the melt curve to be displayed (the temperature at which the transition between single and double stranded states occurs). In addition, sometimes the maximum derivative point may be at too low a temperature (sub 25 degrees) or at too high a temperature (>65). The transition would only occur at some point within this interval, which is what users are concerned with. 

This code change addresses this by calculating the maximum derivative regarding each sample only within the specified range ([25,65] degrees Celsius). In addition, this code adds an annotation next to the dashed line indicating where this occurs, specifying the exact temperature to two decimal places at which this transition occurs. 