### PR TITLE
Van't Hoff, all points removed bug

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -406,7 +406,11 @@ server <- function(input, output, session) {
       # Store the points that are kept vs excluded
       keep <- vantData[vals$keeprows, , drop = FALSE]
       exclude <- vantData[!vals$keeprows, , drop = FALSE]
+    # Check to see if all brush points are removed
 
+    if(nrow(keep) == 0){
+      vals$keeprows <- rep(TRUE, nrow(vantData))
+    }
       # Calculate the R value
       rValue <- format(sqrt(summary(lm(invT ~ lnCt, keep))$r.squared), digits = 3)
 


### PR DESCRIPTION
Checks to see if all points are removed from Vant Hoff. If all points are removed, then it resets the plot to the original values. 